### PR TITLE
corrected case from setbitMode to setBitMode

### DIFF
--- a/src/Shifty.h
+++ b/src/Shifty.h
@@ -11,7 +11,7 @@ class Shifty {
   void setBitCount(int bitCount);
   void setPins(int dataPin, int clockPin, int latchPin, int readPin);
   void setPins(int dataPin, int clockPin, int latchPin);
-  void setbitMode(int bitnum, bool mode);
+  void setBitMode(int bitnum, bool mode);
   bool getBitMode(int bitnum);
   void batchWriteBegin();
   void batchWriteEnd();


### PR DESCRIPTION
The prototype was setbitMode in Shifty.h and setBitMode in Shifty.cpp.  Corrected to setBitMode to be consistent with camel case found in this library.  This fixes a compile error.