### PR TITLE
Do not set input pin direction when there's no need for read function

### DIFF
--- a/src/Shifty.cpp
+++ b/src/Shifty.cpp
@@ -17,11 +17,11 @@ void Shifty::setPins(int dataPin, int clockPin, int latchPin, int readPin) {
   pinMode(dataPin, OUTPUT);
   pinMode(clockPin, OUTPUT);
   pinMode(latchPin, OUTPUT);
-  pinMode(readPin, INPUT);
   this->dataPin = dataPin;
   this->clockPin = clockPin;
   this->latchPin = latchPin;
   if(readPin != -1) {
+    pinMode(readPin, INPUT);
     this->readPin = readPin;
   }
 }

--- a/src/Shifty.cpp
+++ b/src/Shifty.cpp
@@ -76,7 +76,7 @@ void Shifty::setBitMode(int bitnum, bool mode) {
 bool Shifty::getBitMode(int bitnum){ //true == input
   int bytenum = bitnum / 8; // get working byte offset
   int offset = bitnum % 8;  // get working bit offset
-  byte b = this->dataModes[bytenum]; //set b to working byte
+  // byte b = this->dataModes[bytenum]; //set b to working byte
   return bitRead(this->dataModes[bytenum], offset);
 }
 
@@ -145,8 +145,8 @@ bool Shifty::readBitHard(int bitnum) {
 void Shifty::readAllBits() {
   for(int i = 0; i < this->byteCount; i++) {
     byte mask = this->dataModes[i];
-    byte outb = this->writeBuffer[i];
-    byte inb = 0;
+    // byte outb = this->writeBuffer[i];
+    // byte inb = 0;
     for(int j = 0; j < 8; j++) {
       if(bitRead(mask, j)) {
         readBitHard(i * 8 + j);


### PR DESCRIPTION
Setting pin number "-1" to INPUT may cause problems on some devices. Therefore, ignore this action when readPin is -1.