### PR TITLE
Correct setPins pin order in example

### DIFF
--- a/examples/SimpleOutputExample/SimpleOutputExample.ino
+++ b/examples/SimpleOutputExample/SimpleOutputExample.ino
@@ -7,7 +7,7 @@ void setup() {
   // Set the number of bits you have (multiples of 8)
   shift.setBitCount(8);
 
-  // Set the clock, data, and latch pins you are using
+  // Set the data, clock and latch pins you are using
   // This also sets the pinMode for these pins
   shift.setPins(11, 12, 8); 
 }


### PR DESCRIPTION
Pin order in example code is clearly specified in the wrong order. 
It's data, clock and latch https://github.com/johnnyb/Shifty/blob/1fe332c9a933f25999ec680a46c8d129840966e6/src/Shifty.cpp#L29 whereas  example incorrectly says 
```c
// Set the clock, data, and latch pins you are using.
```